### PR TITLE
Add persistence option to enable PVC volume mounts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -50,6 +50,11 @@ spec:
           env:
             - name: APP_LOG_LEVEL
               value: warning
+      {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
+          volumeMounts:
+            - name: storage
+              mountPath: "/opt/dreamfactory/storage"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -62,3 +67,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "dreamfactory.fullname" .) }}
+      {{- end -}}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "dreamfactory.fullname" . }}
+  labels:
+    {{- include "dreamfactory.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.persistence.finalizers  }}
+  finalizers:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end -}}
+  {{- with .Values.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+{{ toYaml . | indent 6 }}
+  {{- end }}
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -80,3 +80,17 @@ tolerations: []
 
 affinity: {}
 
+persistence:
+  type: pvc
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # selectorLabels: {}
+  # subPath: ""
+  # existingClaim:
+


### PR DESCRIPTION
Without persistence storage, we lose local data each time pod is evicted from the node. I've added optional support for PVC, by default it is disabled.