### PR TITLE
Add license key Environmental variable to chart

### DIFF
--- a/templates/dreamfactory-deployment.yaml
+++ b/templates/dreamfactory-deployment.yaml
@@ -71,6 +71,10 @@ spec:
             # Add the environment variables for logging configuration
             - name: APP_LOG_LEVEL
               value: debug
+            {{- if .Values.dreamfactory.env.licensekey }}
+            - name: DF_LICENSE_KEY
+              value: {{ .Values.dreamfactory.env.licensekey }}
+            {{- end }}               
           readinessProbe:
             httpGet:
               path: /

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,8 @@ dreamfactory:
       - example.dreamfactory.com
     tls: true
     pathType: Prefix
-
+  env:
+    licensekey: {} # Populate if you have a license key
 
   image:
     repository: dreamfactorysoftware/dreamfactory


### PR DESCRIPTION
Added an environmental variable DF_LICENSE_KEY that populates with a the licensekey value from the values file
- Only adds the environmental variable if there is a value set
Added an entry in the values file with no value for licensekey.